### PR TITLE
Rename coda-hq to coda

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,14 +17,14 @@
     "debug": "~4.3.1",
     "notepack.io": "~2.3.0",
     "redis": "~3.1.2",
-    "socket.io-adapter": "coda-hq/socket.io-adapter",
+    "socket.io-adapter": "coda/socket.io-adapter",
     "uid2": "0.0.3"
   },
   "devDependencies": {
     "expect.js": "0.3.1",
     "ioredis": "^4.17.3",
     "mocha": "^8.1.3",
-    "socket.io": "coda-hq/socket.io",
+    "socket.io": "coda/socket.io",
     "socket.io-client": "latest"
   }
 }


### PR DESCRIPTION
Per discussion from https://codaproject.slack.com/archives/G01K0R0BAPR/p1620658218002900 rename the coda-hq org to coda
